### PR TITLE
Remove onConstructor annotation in lombok (fails javadoc generation)

### DIFF
--- a/stylesniffer-annotation-processor/src/main/java/dev/cookiecode/stylesniffer/annotation/processor/RegisterCaseStyleAnnotationProcessor.java
+++ b/stylesniffer-annotation-processor/src/main/java/dev/cookiecode/stylesniffer/annotation/processor/RegisterCaseStyleAnnotationProcessor.java
@@ -24,7 +24,6 @@ package dev.cookiecode.stylesniffer.annotation.processor;
 
 import static lombok.AccessLevel.*;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Set;
 import javax.annotation.processing.*;
@@ -47,12 +46,8 @@ import lombok.extern.flogger.Flogger;
  * @see dev.cookiecode.stylesniffer.api.CaseStyle
  */
 @NoArgsConstructor(access = PUBLIC)
-@AllArgsConstructor(
-    access = PACKAGE,
-    onConstructor_ = {@VisibleForTesting})
-@Getter(
-    value = PACKAGE,
-    onMethod_ = {@VisibleForTesting})
+@AllArgsConstructor(access = PACKAGE)
+@Getter(value = PACKAGE)
 @SupportedAnnotationTypes("dev.cookiecode.stylesniffer.annotation.RegisterCaseStyle")
 @SupportedSourceVersion(SourceVersion.RELEASE_21)
 @Flogger

--- a/stylesniffer-annotation-processor/src/main/java/dev/cookiecode/stylesniffer/annotation/processor/TemplateRenderer.java
+++ b/stylesniffer-annotation-processor/src/main/java/dev/cookiecode/stylesniffer/annotation/processor/TemplateRenderer.java
@@ -49,7 +49,7 @@ import org.thymeleaf.context.Context;
  * @author Sebastien Vermeille
  * @see org.thymeleaf.context.Context
  */
-@RequiredArgsConstructor(onConstructor_ = {@VisibleForTesting})
+@RequiredArgsConstructor()
 public class TemplateRenderer {
 
   static final String TEMPLATE_FILE_NAME = "case_style_injector";


### PR DESCRIPTION
As it's not really important it can be removed at least for now.